### PR TITLE
Version bump to v1.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "oak-lite",
   "description": "A lightweight version of Oak, a write-only database with a publish-subscribe model",
-  "version": "1.0.0-alpha.2",
+  "version": "1.0.0",
   "author": "Trevin Hofmann <trevinhofmann@gmail.com>",
   "scripts": {
     "build": "grunt build",


### PR DESCRIPTION
### Summary

Prepare for first release. No changes since `1.0.0-alpha.2`.