### PR TITLE
Phrasing: append-only, not write-only

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 [![Dependency Status](https://david-dm.org/oak-database/oak-lite/status.svg)](https://david-dm.org/oak-database/oak-lite)
 [![devDependency Status](https://david-dm.org/oak-database/oak-lite/dev-status.svg)](https://david-dm.org/oak-database/oak-lite?type=dev)
 
-Oak-Lite is a lightweight version of Oak, a write-only database with a publish-subscribe model.
+Oak-Lite is a lightweight version of Oak, an append-only database with a publish-subscribe model.
 
 ## Getting Started
 

--- a/package.json
+++ b/package.json
@@ -23,7 +23,6 @@
     "lite",
     "database",
     "append-only",
-    "write-only",
     "pubsub"
   ],
   "engines": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "oak-lite",
-  "description": "A lightweight version of Oak, a write-only database with a publish-subscribe model",
+  "description": "A lightweight version of Oak, an append-only database with a publish-subscribe model",
   "version": "1.0.0",
   "author": "Trevin Hofmann <trevinhofmann@gmail.com>",
   "scripts": {


### PR DESCRIPTION
### Summary

Changes phrasing from "write-only" to "append-only", to be more accurate.